### PR TITLE
Swifty interface changes and minor API improvements

### DIFF
--- a/src/Caffe2.h
+++ b/src/Caffe2.h
@@ -8,10 +8,12 @@
 
 #import <UIKit/UIKit.h>
 
-@interface Caffe2 : NSObject
+@interface Caffe2: NSObject
+- (null_unspecified instancetype)init UNAVAILABLE_ATTRIBUTE;
 
-- (instancetype) init:(nonnull NSString*) initNetFilename predict:(nonnull NSString*) predictNetFilename;
+- (null_unspecified instancetype) init:(nonnull NSString*)initNetFilename predict:(nonnull NSString*)predictNetFilename error:(NSError**)error
+NS_SWIFT_NAME(init(initializingNetNamed:predictingNetNamed:));
 
-- (nullable NSArray<NSNumber*>*) predict:(nonnull UIImage*) image;
-
+- (nullable NSArray<NSNumber*>*) predict:(nonnull UIImage*) image
+NS_SWIFT_NAME(prediction(regarding:));
 @end


### PR DESCRIPTION
1. swift3 conventions naming in header
2. init() not exposed
3. throwing initializer throws if pb files with requested names are not found in bundle
4. deallocator closing protobuf