### PR TITLE
Fix build scripts and podspec

### DIFF
--- a/Caffe2Kit.podspec
+++ b/Caffe2Kit.podspec
@@ -31,15 +31,15 @@ Pod::Spec.new do |s|
       ss.preserve_paths = 'install/include/**/*.h', 'install/include/Eigen/*', 'lib/caffe2/LICENSE', 'lib/caffe2/PATENTS'
 
       ss.xcconfig = {
-        'HEADER_SEARCH_PATHS' =>  '$(inherited) "$(PODS_ROOT)/Caffe2Kit/install/include/" "$(PODS_ROOT)/Caffe2Kit/install/include/Eigen/"',
-        'OTHER_LDFLAGS' => '-force_load "$(PODS_ROOT)/Caffe2Kit/install/lib/libCaffe2_CPU.a"'
+        'HEADER_SEARCH_PATHS' =>  '$(inherited) "$(PODS_TARGET_SRCROOT)/install/include/" "$(PODS_TARGET_SRCROOT)/install/include/Eigen/"',
+        'OTHER_LDFLAGS' => '-force_load "$(PODS_TARGET_SRCROOT)/install/lib/libCaffe2_CPU.a"'
       }
 
       ss.vendored_libraries  = 'install/lib/libCaffe2_CPU.a',
-                                'install/lib/libprotobuf-lite.a',
-                                'install/lib/libprotobuf.a',
-                                'install/lib/libCAFFE2_NNPACK.a',
-                                'install/lib/libCAFFE2_PTHREADPOOL.a'
+                               'install/lib/libprotobuf-lite.a',
+                               'install/lib/libprotobuf.a',
+                               'install/lib/libCAFFE2_NNPACK.a',
+                               'install/lib/libCAFFE2_PTHREADPOOL.a'
       ss.libraries =  'stdc++'
     end
 

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -5,10 +5,6 @@ SCRIPTS_DIR="$( cd "$(dirname "$0")"; pwd -P)"
 CAFFE2_ROOT="$( cd "$(dirname "$0")"/../lib/caffe2 ; pwd -P)"
 INSTALL_ROOT_DIR="$SCRIPTS_DIR/../install"
 
-echo "     SCRIPTS_DIR = $SCRIPTS_DIR"
-echo "     CAFFE2_ROOT = $CAFFE2_ROOT"
-echo "INSTALL_ROOT_DIR = $INSTALL_ROOT_DIR"
-
 mkdir -p $INSTALL_ROOT_DIR
 
 ## SIMULATOR
@@ -39,9 +35,9 @@ make install
 
 # Build for WatchOS
 BUILD_DIR="build_watchos_pod"
-# if [ ! -d "$CAFFE2_ROOT/$BUILD_DIR" ]; then
+if [ ! -d "$CAFFE2_ROOT/$BUILD_DIR" ]; then
   IOS_PLATFORM=WATCHOS BUILD_DIR=$BUILD_DIR INSTALL_DIR="$INSTALL_ROOT_DIR/watchos" $SCRIPTS_DIR/build_ios_pod.sh
-# fi
+fi
 cd "$CAFFE2_ROOT/$BUILD_DIR"
 
 # copy missing protoc files to build directory... not sure why they are in the wrong location

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
+set -e -o nounset
 
 SCRIPTS_DIR="$( cd "$(dirname "$0")"; pwd -P)"
 CAFFE2_ROOT="$( cd "$(dirname "$0")"/../lib/caffe2 ; pwd -P)"
-
 INSTALL_ROOT_DIR="$SCRIPTS_DIR/../install"
+
+echo "     SCRIPTS_DIR = $SCRIPTS_DIR"
+echo "     CAFFE2_ROOT = $CAFFE2_ROOT"
+echo "INSTALL_ROOT_DIR = $INSTALL_ROOT_DIR"
+
 mkdir -p $INSTALL_ROOT_DIR
 
 ## SIMULATOR
@@ -17,8 +22,7 @@ cd "$CAFFE2_ROOT/$BUILD_DIR"
 # copy missing protoc files to build directory... not sure why they are in the wrong location
 cp -rf $CAFFE2_ROOT/build_host_protoc/lib/libprotoc.a ./third_party/protobuf/cmake/libprotoc.a
 cp -rf $CAFFE2_ROOT/build_host_protoc/bin/protoc ./third_party/protobuf/cmake/protoc
-
-#make install
+make install
 
 ## DEVICE
 # Build for iOS
@@ -31,21 +35,19 @@ cd "$CAFFE2_ROOT/$BUILD_DIR"
 # copy missing protoc files to build directory... not sure why they are in the wrong location
 cp -rf $CAFFE2_ROOT/build_host_protoc/lib/libprotoc.a ./third_party/protobuf/cmake/libprotoc.a
 cp -rf $CAFFE2_ROOT/build_host_protoc/bin/protoc ./third_party/protobuf/cmake/protoc
-
-#make install
+make install
 
 # Build for WatchOS
 BUILD_DIR="build_watchos_pod"
-if [ ! -d "$CAFFE2_ROOT/$BUILD_DIR" ]; then
+# if [ ! -d "$CAFFE2_ROOT/$BUILD_DIR" ]; then
   IOS_PLATFORM=WATCHOS BUILD_DIR=$BUILD_DIR INSTALL_DIR="$INSTALL_ROOT_DIR/watchos" $SCRIPTS_DIR/build_ios_pod.sh
-fi
+# fi
 cd "$CAFFE2_ROOT/$BUILD_DIR"
 
 # copy missing protoc files to build directory... not sure why they are in the wrong location
 cp -rf $CAFFE2_ROOT/build_host_protoc/lib/libprotoc.a ./third_party/protobuf/cmake/libprotoc.a
 cp -rf $CAFFE2_ROOT/build_host_protoc/bin/protoc ./third_party/protobuf/cmake/protoc
-
-#make install
+make install
 
 # merge static libs (fat binaries)
 mkdir -p "$INSTALL_ROOT_DIR/lib/"
@@ -54,14 +56,13 @@ lipo -create \
   -output "$INSTALL_ROOT_DIR/lib/libCAFFE2_NNPACK.a"
 
 lipo -create \
-"$CAFFE2_ROOT/build_ios_pod/libCAFFE2_PTHREADPOOL.a" \
--output "$INSTALL_ROOT_DIR/lib/libCAFFE2_PTHREADPOOL.a"
-
+  "$CAFFE2_ROOT/build_ios_pod/libCAFFE2_PTHREADPOOL.a" \
+  -output "$INSTALL_ROOT_DIR/lib/libCAFFE2_PTHREADPOOL.a"
 
 lipo -create \
-"$INSTALL_ROOT_DIR/arm/lib/libCaffe2_CPU.a" \
-"$INSTALL_ROOT_DIR/x86_64/lib/libCaffe2_CPU.a" \
--output "$INSTALL_ROOT_DIR/lib/libCaffe2_CPU.a"
+  "$INSTALL_ROOT_DIR/arm/lib/libCaffe2_CPU.a" \
+  "$INSTALL_ROOT_DIR/x86_64/lib/libCaffe2_CPU.a" \
+  -output "$INSTALL_ROOT_DIR/lib/libCaffe2_CPU.a"
 
 lipo -create \
 "$INSTALL_ROOT_DIR/arm/lib/libprotobuf-lite.a" \
@@ -75,5 +76,5 @@ lipo -create \
 
 # copy headers
 mkdir -p "$INSTALL_ROOT_DIR/include"
-cp -rf "$INSTALL_ROOT_DIR/arm/include/*" "$INSTALL_ROOT_DIR/include/"
-cp -rf "$CAFFE2_ROOT/third_party/eigen/Eigen/*" "$INSTALL_ROOT_DIR/include/Eigen/"
+cp -rf "$INSTALL_ROOT_DIR/arm/include/" "$INSTALL_ROOT_DIR/include/"
+cp -rf "$CAFFE2_ROOT/third_party/eigen/Eigen/" "$INSTALL_ROOT_DIR/include/Eigen/"

--- a/scripts/build_ios_pod.sh
+++ b/scripts/build_ios_pod.sh
@@ -27,8 +27,12 @@ if [ -z ${IOS_PLATFORM+x} ]; then
   # IOS_PLATFORM is not set, in which case we will default to OS, which
   # builds iOS.
   IOS_PLATFORM=SIMULATOR
+fi
+
+if [ "$IOS_PLATFORM" = "SIMULATOR" ]; then
   USE_NNPACK=OFF
 fi
+
 if [ -z ${INSTALL_DIR+x} ]; then
   # INSTALL_DIR is not set, in which case we will default to ../install
   INSTALL_DIR="../install"
@@ -39,7 +43,6 @@ fi
 
 echo "Building for $IOS_PLATFORM"
 echo "Installing to $INSTALL_DIR"
-
 cmake .. \
   -DCMAKE_TOOLCHAIN_FILE=$CAFFE2_ROOT/third_party/ios-cmake/toolchain/iOS.cmake\
   -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \


### PR DESCRIPTION
- In the `build_all.sh` script I uncommented some of the `make install` commands
- In the `build_ios_pod.sh` script I changed the logic for setting `USE_NNPACK`. The old logic was failing when `IOS_PLATFORM` was defined outside of `build_ios_pod.sh`
- The changes in the podspec file fixed issues I was having when using this as a local pod (incorrect header search paths)